### PR TITLE
fix: update error handling for payInvoice and trackPayment

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,0 +1,46 @@
+name: 'Check code'
+
+on:
+  push:
+    paths-ignore:
+      - 'umbrel-app/**'
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.env.*'
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - 'umbrel-app/**'
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.env.*'
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        node: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run lint check
+        run: pnpm lint:check
+      - name: Run prettier check
+        run: pnpm prettier:check

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -21,10 +21,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20.x, 22.x]
-
     steps:
       - uses: actions/checkout@v4
       - name: Install pnpm
@@ -34,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20.x
       - name: Install dependencies
         run: pnpm install
       - name: Run lint check

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -20,12 +20,9 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
         node: [20.x, 22.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+
+on:
+  push:
+    paths-ignore:
+      - 'umbrel-app/**'
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.env.*'
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - 'umbrel-app/**'
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.env.*'
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+        node: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run tests
+        run: pnpm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,9 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - windows-latest
         node: [20.x, 22.x]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "clean": "rm -rf dist .coverage",
     "reset": "pnpm clean; rm -rf node_modules pnpm-lock.yaml; pnpm install",
     "lint": "eslint src tests --fix",
-    "prettier": "prettier src tests --write"
+    "lint:check": "eslint src tests",
+    "prettier": "prettier src tests --write",
+    "prettier:check": "prettier src tests --check"
   },
   "keywords": [],
   "author": "Agustin Kassis",

--- a/src/nostr/internalTransaction.ts
+++ b/src/nostr/internalTransaction.ts
@@ -226,17 +226,22 @@ const getHandler = (ctx: Context): ((event: NostrEvent) => void) => {
               .digest('hex')
           ) {
             error('INVALID PREIMAGE ON "SUCCEEDED" PAYMENT %O', payment);
+            throw new Error('Invalid preimage');
           }
           const preimage = payment.payment_preimage;
           await markPaid(target, startEvent, prHash, preimage, ctx);
-        })
-        .catch((err) => {
-          warn('Failed Tracking payment, reverting transaction: %O', err);
-          doRevertTx(ctx.outbox, startEvent);
-        })
-        .finally(async () => {
           await redis.decr(`p:${prHash}`);
           await markHandled(eventId);
+        })
+        .catch(async (err) => {
+          if ('status' in err && err.status === 'FAILED') {
+            warn('Failed Tracking payment, reverting transaction: %O', err);
+            doRevertTx(ctx.outbox, startEvent);
+            await redis.decr(`p:${prHash}`);
+            await markHandled(eventId);
+            return;
+          }
+          error('Failed Tracking payment: %O', err);
         });
       return;
     }
@@ -311,17 +316,22 @@ const getHandler = (ctx: Context): ((event: NostrEvent) => void) => {
             .digest('hex')
         ) {
           error('INVALID PREIMAGE ON "SUCCEEDED" PAYMENT %O', payment);
+          throw new Error('Invalid preimage');
         }
         const preimage = payment.payment_preimage;
         await markPaid(target, startEvent, prHash, preimage, ctx);
-      })
-      .catch((err) => {
-        warn('Failed paying invoice, reverting transaction: %O', err);
-        doRevertTx(ctx.outbox, startEvent);
-      })
-      .finally(async () => {
         await redis.decr(`p:${prHash}`);
         await markHandled(eventId);
+      })
+      .catch(async (err) => {
+        if ('status' in err && err.status === 'FAILED') {
+          warn('Failed paying invoice, reverting transaction: %O', err);
+          doRevertTx(ctx.outbox, startEvent);
+          await redis.decr(`p:${prHash}`);
+          await markHandled(eventId);
+          return;
+        }
+        error('Failed paying invoice: %O', err);
       });
   };
 };

--- a/src/services/lnd.ts
+++ b/src/services/lnd.ts
@@ -163,7 +163,7 @@ export class LndService {
         if ('SUCCEEDED' === res.status) {
           resolve(res);
         } else {
-          reject(res.failure_reason);
+          reject(res);
         }
       });
       call.on('error', (e: Error) => reject(e));
@@ -182,7 +182,7 @@ export class LndService {
         if ('SUCCEEDED' === res.status) {
           resolve(res);
         } else {
-          reject(res.failure_reason);
+          reject(res);
         }
       });
       call.on('error', (e: Error) => reject(e));

--- a/tests/services/lnd.test.ts
+++ b/tests/services/lnd.test.ts
@@ -103,7 +103,6 @@ describe('lnd service', () => {
     await expect(lnd.payInvoice(pr, 1000)).rejects.toEqual(failedPayment);
   });
 
-  // Tests for trackPayment
   describe('trackPayment', () => {
     it('should track a payment successfully', async () => {
       const successfulPayment = {

--- a/tests/services/lnd.test.ts
+++ b/tests/services/lnd.test.ts
@@ -20,6 +20,7 @@ const lndGrcpMock = {
     },
     Router: {
       sendPaymentV2: jest.fn(),
+      trackPaymentV2: jest.fn(),
     },
   },
 };
@@ -43,6 +44,9 @@ describe('lnd service', () => {
   const lnd = new LndService('', outbox);
   const pr =
     'lnbc15u1p3xnhl2pp5jptserfk3zk4qy42tlucycrfwxhydvlemu9pqr93tuzlv9cc7g3sdqsvfhkcap3xyhx7un8cqzpgxqzjcsp5f8c52y2stc300gl6s4xswtjpc37hrnnr3c9wvtgjfuvqmpm35evq9qyyssqy4lgd8tj637qcjp05rdpxxykjenthxftej7a2zzmwrmrl70fyj9hvj0rewhzj7jfyuwkwcg9g2jpwtk3wkjtwnkdks84hsnu8xps5vsq4gj5hs';
+  const paymentHash =
+    '4185fab4f82fe707648d99c0714a32a354950a31c928e37701b18f29be44e070';
+
   it('should generate invoice', async () => {
     lndGrcpMock.services.Lightning.addInvoice.mockResolvedValue({
       payment_request: pr,
@@ -55,6 +59,7 @@ describe('lnd service', () => {
     );
     expect(invoice).toBe(pr);
   });
+
   it('should generate invoice with comment', async () => {
     const memo = 'To the moon!';
     lndGrcpMock.services.Lightning.addInvoice.mockResolvedValue({
@@ -68,6 +73,7 @@ describe('lnd service', () => {
     );
     expect(invoice).toBe(pr);
   });
+
   it('should pay an invoice', async () => {
     lndGrcpMock.services.Router.sendPaymentV2.mockReturnValue({
       on: jest.fn((_event, callback) => {
@@ -81,13 +87,107 @@ describe('lnd service', () => {
       expect.objectContaining({ payment_request: pr }),
     );
   });
+
   it('should reject on failed payment', async () => {
+    const failedPayment = {
+      status: 'FAILED',
+      failure_reason: 'FAILURE_REASON_ERROR',
+      payment_preimage: '',
+    };
     lndGrcpMock.services.Router.sendPaymentV2.mockReturnValue({
       on: jest.fn((_event, callback) => {
-        callback({ status: 'FAILED', failure_reason: 'FAILURE_REASON_ERROR' });
+        callback(failedPayment);
       }),
     });
 
-    await expect(lnd.payInvoice(pr, 1000)).rejects.toBe('FAILURE_REASON_ERROR');
+    await expect(lnd.payInvoice(pr, 1000)).rejects.toEqual(failedPayment);
+  });
+
+  // Tests for trackPayment
+  describe('trackPayment', () => {
+    it('should track a payment successfully', async () => {
+      const successfulPayment = {
+        status: 'SUCCEEDED',
+        payment_preimage:
+          '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+        failure_reason: undefined,
+      };
+
+      lndGrcpMock.services.Router.trackPaymentV2.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'data') {
+            callback(successfulPayment);
+          }
+          return { on: jest.fn() };
+        }),
+      });
+
+      const result = await lnd.trackPayment(paymentHash);
+
+      expect(lndGrcpMock.services.Router.trackPaymentV2).toHaveBeenCalledWith({
+        payment_hash: Buffer.from(paymentHash, 'hex'),
+        no_inflight_updates: true,
+      });
+      expect(result).toEqual(successfulPayment);
+    });
+
+    it('should reject with full payment object when payment has FAILED status', async () => {
+      const failedPayment = {
+        status: 'FAILED',
+        failure_reason: 'FAILURE_REASON_TIMEOUT',
+        payment_preimage: '',
+      };
+
+      lndGrcpMock.services.Router.trackPaymentV2.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'data') {
+            callback(failedPayment);
+          }
+          return { on: jest.fn() };
+        }),
+      });
+
+      await expect(lnd.trackPayment(paymentHash)).rejects.toEqual(
+        failedPayment,
+      );
+    });
+
+    it('should reject with full payment object for non SUCCEEDED/FAILED status', async () => {
+      const initiatedPayment = {
+        status: 'INITIATED',
+        failure_reason: undefined,
+        payment_preimage: '',
+      };
+
+      lndGrcpMock.services.Router.trackPaymentV2.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'data') {
+            callback(initiatedPayment);
+          }
+          return { on: jest.fn() };
+        }),
+      });
+
+      await expect(lnd.trackPayment(paymentHash)).rejects.toEqual(
+        initiatedPayment,
+      );
+    });
+
+    it('should reject with Error object on connection issues', async () => {
+      const connectionError = new Error('Connection error');
+
+      lndGrcpMock.services.Router.trackPaymentV2.mockReturnValue({
+        on: jest.fn((event, callback) => {
+          if (event === 'error') {
+            callback(connectionError);
+          }
+          return { on: jest.fn() };
+        }),
+      });
+
+      await expect(lnd.trackPayment(paymentHash)).rejects.toEqual(
+        connectionError,
+      );
+    });
   });
 });


### PR DESCRIPTION
this PR fix error handling and status updates for trackPayment and payInvoice in lnd service. Probably this is the fix for `IS-0005: Problema al retornar hold invoice`.

the main problems are:
-  lnd service is using reject for `error` and `data` events so a failed payment has the same behavior of a connection error
- internalTransaction handler is executing doRevertTx for all the errors (payment failed or other errors)

### solution

We have different options but in this case I decided to continue the use of reject for failed payments but returning the whole object and doing the validation in the catch (an alternative is use resolve for every data event and update the handler in internalTransaction).

Please validate specially the changes of this
```js
await redis.decr(`p:${prHash}`);
await markHandled(eventId);
``` 
I dont know exactly how the event stream works so please validate if we always need to mark as handled the event, even for ex for lnd connection issues

ps: I added gh actions for tests and check code (lint and prettier)